### PR TITLE
Fix: 채팅방 입장 api 에러 수정

### DIFF
--- a/src/main/java/Auction_shop/auction/chat/common/MongoConfiguration.java
+++ b/src/main/java/Auction_shop/auction/chat/common/MongoConfiguration.java
@@ -3,6 +3,7 @@ package Auction_shop.auction.chat.common;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.mongodb.MongoDatabaseFactory;
+import org.springframework.data.mongodb.config.EnableMongoAuditing;
 import org.springframework.data.mongodb.core.convert.DbRefResolver;
 import org.springframework.data.mongodb.core.convert.DefaultDbRefResolver;
 import org.springframework.data.mongodb.core.convert.DefaultMongoTypeMapper;
@@ -10,6 +11,7 @@ import org.springframework.data.mongodb.core.convert.MappingMongoConverter;
 import org.springframework.data.mongodb.core.mapping.MongoMappingContext;
 
 @Configuration
+@EnableMongoAuditing
 public class MongoConfiguration {
     /**
      * mongodb 내 _class column 제거

--- a/src/main/java/Auction_shop/auction/chat/controller/ChatController.java
+++ b/src/main/java/Auction_shop/auction/chat/controller/ChatController.java
@@ -26,7 +26,7 @@ public class ChatController {
         String destination = "/sub/chatroom/" + roomId;
         chatService.createChat(chat);
         try {
-            messagingTemplate.convertAndSend(destination, chat.get메세지());   // 도착 경로로 메세지 전달
+            messagingTemplate.convertAndSend(destination, chat.getMessage());   // 도착 경로로 메세지 전달
         } catch (Exception e) {
             log.error("ChatError = {}", e);
             messagingTemplate.convertAndSend(destination, "Error:" + e.getMessage());

--- a/src/main/java/Auction_shop/auction/chat/domain/Chat.java
+++ b/src/main/java/Auction_shop/auction/chat/domain/Chat.java
@@ -20,9 +20,9 @@ public class Chat {
     @Id
     private String id;
     private Long roomId; // 채팅방번호
-    private String 유저ID;
-    private String 메세지;
+    private String userId;
+    private String message;
 
     @CreatedDate
-    private LocalDateTime 생성시간;
+    private LocalDateTime createdAt;
 }

--- a/src/main/java/Auction_shop/auction/chat/dto/ChatDto.java
+++ b/src/main/java/Auction_shop/auction/chat/dto/ChatDto.java
@@ -5,7 +5,7 @@ import java.time.LocalDateTime;
 public class ChatDto {
     private String id;
     private Long roomId; // 채팅방번호
-    private String 유저ID;
-    private String 메세지;
-    private LocalDateTime 생성시간;
+    private String userId;
+    private String message;
+    private LocalDateTime createdAt;
 }

--- a/src/main/java/Auction_shop/auction/chat/dto/ChatDto.java
+++ b/src/main/java/Auction_shop/auction/chat/dto/ChatDto.java
@@ -3,7 +3,7 @@ package Auction_shop.auction.chat.dto;
 import java.time.LocalDateTime;
 
 public class ChatDto {
-    private Long id;
+    private String id;
     private Long roomId; // 채팅방번호
     private String 유저ID;
     private String 메세지;


### PR DESCRIPTION
ChatDto의 id 타입을 String으로 수정했습니다.

MongoConfiguration 클래스에 @EnableMongoAuditing를 추가하여 auditing 기능을 활성화하였고 Chat 테이블에 생성시간이
저장되는 것까지 테스트했습니다.

Chat,ChatRoom 클래스의 한글로 되어있던 변수명들을 영어로 변경하였습니다.
