### PR TITLE
Feat: 회원 탈퇴를 위한 메서드 추가

### DIFF
--- a/src/main/java/Auction_shop/auction/domain/product/repository/ProductJpaRepository.java
+++ b/src/main/java/Auction_shop/auction/domain/product/repository/ProductJpaRepository.java
@@ -32,6 +32,9 @@ public interface ProductJpaRepository extends JpaRepository<Product,Long> {
 
     List<Product> findAllByMemberId(Long memberId);
 
+    @Query("SELECT COUNT(p) > 0 FROM Product p WHERE p.member.id = :memberId AND p.isSold = false")
+    boolean existsActiveProductsByMemberId(@Param("memberId") Long memberId);
+
     //동시성 방지를 위해 Lock 을 건 물건 반환
     @Lock(LockModeType.PESSIMISTIC_WRITE)
     @Query("SELECT p FROM Product p WHERE p.id = :productId")

--- a/src/main/java/Auction_shop/auction/domain/product/service/ProductServiceImpl.java
+++ b/src/main/java/Auction_shop/auction/domain/product/service/ProductServiceImpl.java
@@ -287,7 +287,7 @@ public class ProductServiceImpl implements ProductService {
 
             List<Product> updatedProducts = new ArrayList<>();
             for (Product product : page.getContent()) {
-                if (currentTime.isAfter(product.getUpdateTime().plusSeconds(8))) {
+                if (currentTime.isAfter(product.getUpdateTime().plusMinutes(1))) {
                     int newPrice = product.getCurrent_price() - (product.getInitial_price() / (int) product.getTotalHours());
                     if (newPrice < product.getMinimum_price()) {
                         newPrice = product.getMinimum_price();


### PR DESCRIPTION
1. memberId에 해당하는 경매 물품 중 sold 값이 false인 값이 있으면 true, 없으면 false 반환 (true가 나오면 회원 탈퇴를 못하게)
2. 원활한 테스트를 위해 하향식 경매 물품의 가격 내려가는 텀을 1분으로 수정