### PR TITLE
fix: 채팅방 퇴장 수정

### DIFF
--- a/src/main/java/Auction_shop/auction/chatRoom/controller/ChatRoomController.java
+++ b/src/main/java/Auction_shop/auction/chatRoom/controller/ChatRoomController.java
@@ -84,9 +84,9 @@ public class ChatRoomController {
     /**
      * 채팅방 퇴장
      */
-    @PostMapping("/chatroom/delete/{userId}/{postId}")
-    public ResponseEntity<String> delete(@PathVariable Long userId, @PathVariable Long postId) {
-        ChatRoom deleteRoom = chatRoomService.deleteChatRoom(userId, postId);
+    @PostMapping("/chatroom/delete/{userId}/{roomId}")
+    public ResponseEntity<String> delete(@PathVariable Long userId, @PathVariable Long roomId) {
+        ChatRoom deleteRoom = chatRoomService.deleteChatRoom(userId, roomId);
 
         if (deleteRoom == null) {
             return ResponseEntity.status(404).body("delete failed");

--- a/src/main/java/Auction_shop/auction/chatRoom/repository/ChatRoomRepository.java
+++ b/src/main/java/Auction_shop/auction/chatRoom/repository/ChatRoomRepository.java
@@ -10,7 +10,7 @@ public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
     List<ChatRoom> findByUserId(Long userId);
     ChatRoom findFirstByRoomId(Long roomId);
     ChatRoom findByUserIdAndYourIdAndPostId(Long userId, Long yourId, Long postId);
-    ChatRoom deleteChatRoomByUserIdAndPostId(Long userId, Long postId);
+    ChatRoom deleteChatRoomByUserIdAndRoomId(Long userId, Long roomId);
     ChatRoom findByYourIdAndRoomId(Long userId, Long roomId);
 
     @Query("SELECT COUNT(CR) FROM ChatRoom CR")

--- a/src/main/java/Auction_shop/auction/chatRoom/service/ChatRoomService.java
+++ b/src/main/java/Auction_shop/auction/chatRoom/service/ChatRoomService.java
@@ -14,6 +14,6 @@ public interface ChatRoomService {
     Long createNewChatRoom(Long userId, Long yourId, Long postId);
     ChatRoomInfoResponseDto enterChatRoom(Long roomId);
     Member findMemberByChatRoom(Long roomId);
-    ChatRoom deleteChatRoom(Long userId, Long postId);
+    ChatRoom deleteChatRoom(Long userId, Long roomId);
     ChatRoom isOtherUserLeft(Long userId, Long roomId);
 }

--- a/src/main/java/Auction_shop/auction/chatRoom/service/ChatRoomServiceImpl.java
+++ b/src/main/java/Auction_shop/auction/chatRoom/service/ChatRoomServiceImpl.java
@@ -158,8 +158,8 @@ public class ChatRoomServiceImpl implements ChatRoomService {
      */
     @Transactional
     @Override
-    public ChatRoom deleteChatRoom(Long userId, Long postId) {
-        ChatRoom deleteRoom = chatRoomRepository.deleteChatRoomByUserIdAndPostId(userId, postId);
+    public ChatRoom deleteChatRoom(Long userId, Long roomId) {
+        ChatRoom deleteRoom = chatRoomRepository.deleteChatRoomByUserIdAndRoomId(userId, roomId);
         return deleteRoom;
     }
 


### PR DESCRIPTION
/chatroom/delete/{userId}/{postId} -> /chatroom/delete/{userId}/{roomId}
postId 대신 roomId로 변경하여 userId,roomId로 채팅방 데이터 삭제